### PR TITLE
update cargo command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.32.0 as builder
 
 COPY . .
 
-RUN cargo install --root /usr/local
+RUN cargo install --path . --root /usr/local
 
 FROM debian:stretch-slim as runner
 


### PR DESCRIPTION
the cargo command is old and returns ```error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.```